### PR TITLE
updating with HFH modifications

### DIFF
--- a/gis_operations.py
+++ b/gis_operations.py
@@ -2,7 +2,7 @@ from __future__ import division
 from pyproj import Proj
 
 def compute_lat_lon(x, y, utm_zone):
-    p = Proj(proj='utm', zone=utm_zone, ellps='WGS84')
+    p = Proj(proj='utm', zone=str(abs(int(utm_zone))), ellps='WGS84')
     lat, lon = p(x, y, inverse=True)
     return [lat, lon]
 
@@ -19,6 +19,10 @@ def compute_tile_coords(row, col, width, height, config):
     top = scene_top + ((row * config.GRID_SIZE) / config.height) * scene_span_y
     right = left + (width / config.width) * scene_span_x
     bottom = top + (height / config.height) * scene_span_y
+    
+    if int(config.METADATA['#utm_zone']) < 0:
+        top = top - 10000000
+        bottom = bottom - 10000000
 
     return [left, top, right, bottom]
 

--- a/simple.py
+++ b/simple.py
@@ -198,6 +198,9 @@ def build_dict_for_csv(filename, reason, config):
 
     my_dict.update(coordinate_metadata)
     my_dict.update(config.METADATA)
+    
+    my_dict['#utm_zone'] = str(abs(int(my_dict['#utm_zone'])))
+    
     return my_dict
 
 


### PR DESCRIPTION
Fixes southern hemisphere bug.  Here is Henry's email to me detailing the fixes:

Jarrett-

I’ve attached two updated python scripts below. I appended ‘_HFH' for your version control, which would need to be edited out to run.

I retained the LANDSAT negative northing usage, because it simplifies the code edits. There are 3 changes:

1. In <gis_operations.py> I’ve modified line 5 (in compute_lat_lon):
    p = Proj(proj='utm', zone=str(abs(int(utm_zone))), ellps='WGS84')

This is where pyproj is calling Proj. I think that Proj versions 5 or newer are compatible with negative northings, so as long as you had Proj version 5 or newer, you can revert the pyproj version update from our earlier email (sorry).

2. In <gis_operations.py> I’ve added a conditional statement on line 23 (in compute_tile_coords; note indentation):
    if int(config.METADATA['#utm_zone']) < 0:
        top = top - 10000000
        bottom = bottom - 10000000

This applies an offset to southern hemisphere y values.

3. In <simple.py> I’ve added to line 202 (in build_dict_for_csv):

    my_dict['#utm_zone'] = str(abs(int(my_dict['#utm_zone'])))

This causes the UTM to be positive in the manifest file (since the y values have earlier been updated to be negative for the southern hemisphere).

These edits are only based on the conventions that I’ve encountered for a small number of scenes… (and only including L05 and L08).

Thanks,
Henry